### PR TITLE
chore: configure Dependabot with assignees

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+- package-ecosystem: bundler
+  directory: /
+  schedule:
+    interval: weekly
+  assignees:
+  - cjsaylor
+  open-pull-requests-limit: 10
+- package-ecosystem: npm
+  directory: /
+  schedule:
+    interval: weekly
+  assignees:
+  - cjsaylor
+  open-pull-requests-limit: 10


### PR DESCRIPTION
## What this PR does

This PR configures Dependabot for this repository.

- Adds/updates `.github/dependabot.yml`
- Assigns PRs to the designated team lead(s)

> Auto-generated by the Dependabot setup script.
